### PR TITLE
fixes Linker Warning

### DIFF
--- a/src/server/game/Scripting/ScriptObjectFwd.h
+++ b/src/server/game/Scripting/ScriptObjectFwd.h
@@ -24,7 +24,6 @@
 class AchievementGlobalMgr;
 class AchievementMgr;
 class ArenaTeam;
-class AuctionEntry;
 class AuctionHouseMgr;
 class AuctionHouseObject;
 class Aura;
@@ -98,6 +97,7 @@ enum WeatherState : uint32;
 struct AchievementCriteriaEntry;
 struct AchievementEntry;
 struct AreaTrigger;
+struct AuctionEntry;
 struct CompletedAchievementData;
 struct Condition;
 struct ConditionSourceInfo;


### PR DESCRIPTION
- Fix mismatch between AuctionEntry forward declaration and definition



## Issues Addressed:
Fixed the struct/class mismatch warning for AuctionEntry. The compiler kept complaining about this forward declaration inconsistency which occasionally showed up during builds. It's a tiny change but should make our build output cleaner and prevent potential linker issues when building with MSVC.
